### PR TITLE
Add --scope-file CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Changing the source directory. This is usually `src/` by default in foundry, but
 Don't test files in `--src-dir` that match this regex. This is useful if you have mocks or tests in a subdirectory of `src/`
 
 ```
+--scope-file <file>
+```
+Mutate only the files specified in the provided scope file, where each line should list one file path relative to the project root. This option supersedes `--src-dir`. It is useful if you would like to target a select group of files
+
+```
 --sample-ratio <float [0-1]>
 ```
 Don't run every mutation, but run a percentage of them. Useful if you are just checking if everything works end-to-end

--- a/eth_vertigo/cli/main.py
+++ b/eth_vertigo/cli/main.py
@@ -30,6 +30,7 @@ def cli():
 @cli.command(help="Performs a core test campaign")
 @click.option('--src-dir', help="Output core test results to file", nargs=1, type=str, default="src")
 @click.option('--exclude-regex', help="Output core test results to file", nargs=1, type=str, default="(test|Test|mock|Mock|\.t\.sol)")
+@click.option('--scope-file', help="Only mutate files listed in the specified file", nargs=1, type=str)
 @click.option('--output', help="Output core test results to file", nargs=1, type=str)
 @click.option('--network', help="Network names that vertigo can use", multiple=True)
 @click.option('--ganache-path', help="Path to ganache binary", type=str, default="ganache-cli")
@@ -46,6 +47,7 @@ def cli():
 def run(
         src_dir,
         exclude_regex,
+        scope_file,
         output,
         network,
         ganache_path,
@@ -158,6 +160,7 @@ def run(
                 campaign = FoundryCampaign(
                     src_dir=src_dir,
                     exclude_regex=exclude_regex,
+                    scope_file=scope_file,
                     foundry_command=["forge"],
                     project_directory=project_path,
                     mutators=mutators,


### PR DESCRIPTION
A new --scope-file argument which allows you to only mutate a set of files specified in a scope.txt file.

This is useful when using vertigo-rs in audit contest platforms like C4.